### PR TITLE
CM-9. Make typography component

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,4 +82,6 @@ select {
   --c-disabled-bg-light: #1d1b201f;
   --c-disabled-text-dark: #e6e0e9;
   --c-disabled-bg-dark: #e6e0e91f;
+
+  --font-family-base: 'Roboto', Inter, system-ui, Arial, sans-serif;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,41 @@
-import Button from '@/ui/Button/Button';
-
+import Typography from '@/ui/Typography';
 import styles from './page.module.css';
 
 const HomePage: React.FC = () => {
   return (
     <div>
-      <h1>Проверка состояний кнопки</h1>
-      <Button className={`${styles.upper} ${styles.underline}`}>Чёрная</Button>
-      <Button disabled>Выключенная чёрная</Button>
-      <br />
+      <Typography variant="h1" color="mindal">
+        Компонента h1 <Typography variant="span"> и span</Typography>
+      </Typography>
+      <Typography variant="h2" className={styles.underline}>
+        Компонента h2
+      </Typography>
+      <Typography variant="h3" bold>
+        Компонента h3 + bold
+      </Typography>
+      <Typography variant="h4" style={{ color: 'red' }}>Компонента h4</Typography>
+      <Typography variant="h5">Компонента h5</Typography>
+      <Typography variant="h6">Компонента h6</Typography>
+      <Typography variant="subheading1">Компонента subheading1</Typography>
+      <Typography variant="subheading2">Компонента subheading2</Typography>
+      <Typography variant="body1">Компонента body1</Typography>
+      <Typography variant="body2">Компонента body2</Typography>
 
-      <Button data-text="text" color="white">
-        Белая
-      </Button>
-      <Button color="white" disabled>
-        Выключенная белая
-      </Button>
-      <br />
-
-      <Button color="mindal" style={{ width: '100%' }}>
-        Миндальная
-      </Button>
-      <Button color="mindal" disabled>
-        Выключенная миндальная
-      </Button>
-      <br />
-
-      <Button color="green">Зелёная</Button>
-      <Button color="green" disabled>
-        Выключенная зелёная
-      </Button>
-      <br />
-
-      <Button href="/auth" style={{ width: '100%', textAlign: 'center' }}>
-        Вход
-      </Button>
-      <Button href="/auth" disabled>
-        Выключенная кнопка со ссылкой
-      </Button>
+      <Typography variant="DisplayLarge">Dysplay Large</Typography>
+      <Typography variant="DisplayMedium">Display Medium</Typography>
+      <Typography variant="DisplaySmall">DisplaySmall</Typography>
+      <Typography variant="HeadlineLarge">HeadlineLarge</Typography>
+      <Typography variant="HeadlineMedium">HeadlineMedium</Typography>
+      <Typography variant="HeadlineSmall">HeadlineSmall</Typography>
+      <Typography variant="TitleLarge">TitleLarge</Typography>
+      <Typography variant="TitleMedium">TitleMedium</Typography>
+      <Typography variant="TitleSmall">TitleSmall</Typography>
+      <Typography variant="LabelLarge">LabelLarge</Typography>
+      <Typography variant="LabelMedium">LabelMedium</Typography>
+      <Typography variant="LabelSmall">LabelSmall</Typography>
+      <Typography variant="BodyLarge">BodyLarge</Typography>
+      <Typography variant="BodyMedium">BodyMedium</Typography>
+      <Typography variant="BodySmall">BodySmall</Typography>
     </div>
   );
 };

--- a/src/ui/Typography/Typography.module.css
+++ b/src/ui/Typography/Typography.module.css
@@ -1,0 +1,182 @@
+.base {
+  font-family: var(--font-family-base);
+  margin: 0;
+  padding: 0;
+}
+
+.black {
+  color: var(--c-black);
+}
+
+.white {
+  color: var(--c-white);
+}
+
+.mindal {
+  color: var(--c-mindal);
+}
+
+.green {
+  color: var(--c-green);
+}
+
+.h1 {
+  font-size: 2.8125rem;
+  font-weight: 400;
+  line-height: 3.25rem;
+}
+
+.h2 {
+  font-size: 2rem;
+  font-weight: 400;
+  line-height: 2.5rem;
+}
+
+.h3 {
+  font-size: 1.75rem;
+  font-weight: 400;
+  line-height: 2.25rem;
+}
+
+.h4 {
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 2rem;
+}
+
+.h5 {
+  font-size: 1.375rem;
+  font-weight: 400;
+  line-height: 1.75rem;
+}
+
+.h6 {
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  letter-spacing: 0.00938rem;
+}
+
+.subheading1 {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  letter-spacing: 0.00625rem;
+}
+
+.subheading2 {
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  letter-spacing: 0.03125rem;
+}
+
+.body1 {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  letter-spacing: 0.03125rem;
+}
+
+.body2 {
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  letter-spacing: 0.01563rem;
+}
+
+.DisplayLarge {
+  font-size: 3.5625rem;
+  font-weight: 400;
+  line-height: 4rem;
+  letter-spacing: -0.01563rem;
+}
+.DisplayMedium {
+  font-size: 2.8125rem;
+  font-weight: 400;
+  line-height: 3.25rem;
+}
+.DisplaySmall {
+  font-size: 2.25rem;
+  font-weight: 400;
+  line-height: 2.75rem;
+}
+.HeadlineLarge {
+  font-size: 2rem;
+  font-weight: 400;
+  line-height: 2.5rem;
+}
+.HeadlineMedium {
+  font-size: 1.75rem;
+  font-weight: 400;
+  line-height: 2.25rem;
+}
+.HeadlineSmall {
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 2rem;
+}
+.TitleLarge {
+  font-size: 1.375rem;
+  font-weight: 400;
+  line-height: 1.75rem;
+}
+.TitleMedium {
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  letter-spacing: 0.00938rem;
+}
+.TitleSmall {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  letter-spacing: 0.00625rem;
+}
+.LabelLarge {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  letter-spacing: 0.00625rem;
+}
+.LabelMedium {
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  letter-spacing: 0.03125rem;
+}
+.LabelSmall {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1rem;
+  letter-spacing: 0.03125rem;
+}
+.BodyLarge {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5rem;
+  letter-spacing: 0.03125rem;
+}
+.BodyMedium {
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  letter-spacing: 0.01563rem;
+}
+.BodySmall {
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1rem;
+}
+
+.span {
+  font-size: inherit;
+  font-style: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+
+.bold {
+  font-weight: bolder;
+}

--- a/src/ui/Typography/Typography.tsx
+++ b/src/ui/Typography/Typography.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import styles from './Typography.module.css';
+
+const variants = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
+  subheading1: 'h6',
+  subheading2: 'h6',
+  body1: 'p',
+  body2: 'p',
+  span: 'span',
+
+  DisplayLarge: 'h1',
+  DisplayMedium: 'h1',
+  DisplaySmall: 'h2',
+  HeadlineLarge: 'h2',
+  HeadlineMedium: 'h3',
+  HeadlineSmall: 'h3',
+  TitleLarge: 'h4',
+  TitleMedium: 'h4',
+  TitleSmall: 'h5',
+  LabelLarge: 'h5',
+  LabelMedium: 'h6',
+  LabelSmall: 'h6',
+  BodyLarge: 'p',
+  BodyMedium: 'p',
+  BodySmall: 'p',
+};
+
+type Variant = keyof typeof variants;
+
+interface TypographyProps {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+  className?: string;
+  variant?: Variant;
+  tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
+  color?: 'black' | 'white' | 'mindal' | 'green';
+  bold?: boolean;
+}
+
+const Typography: React.FC<TypographyProps> = ({
+  children,
+  style,
+  className,
+  tag,
+  variant = 'body1',
+  color = 'black',
+  bold = false,
+  ...props
+}) => {
+  const Tag = tag || variants[variant] || 'p';
+
+  const classes = [
+    styles.base,
+    styles[variant],
+    className,
+    color && styles[color],
+    bold && styles.bold,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return React.createElement(
+    Tag,
+    {
+      className: classes,
+      style,
+      ...props,
+    },
+    children,
+  );
+};
+
+export default Typography;

--- a/src/ui/Typography/index.tsx
+++ b/src/ui/Typography/index.tsx
@@ -1,0 +1,3 @@
+import Typography from './Typography';
+
+export default Typography;


### PR DESCRIPTION
![image](https://github.com/CoffeeMapper/frontend/assets/98470175/2c81342a-cc22-4303-a828-0a008fb05a14)

К каждому варианту стилизации присвоен свой тег, его можно переопределить. 
Сделал названия вариантов в двух форматах, наример, h1 дублирует DisplayMedium